### PR TITLE
Change how we pick distro-specific options

### DIFF
--- a/installer/pxe/stage1/debathena/installer.sh
+++ b/installer/pxe/stage1/debathena/installer.sh
@@ -366,7 +366,8 @@ fi
 dkargs="DEBCONF_DEBUG=5"
 
 nodhcp="netcfg/disable_dhcp=true"
-case "$distro" in
+distrobase=$(echo "$distro" | sed -e 's/-.*//')
+case "$distrobase" in
     oneiric|precise|quantal|raring)
         kbdcode="keyboard-configuration/layoutcode=us"
         # "Yay"


### PR DESCRIPTION
If the distro contains a '-', use the first part of it
to pick distro-specific options.  This allows us to do
something like 'precise-testing' and still have it pick
the correct kernel arguments.  This may not DTRT for
raspbian-wheezy
