### PR TITLE
Default to trusty

### DIFF
--- a/installer/pxe/stage1/debathena/installer.sh
+++ b/installer/pxe/stage1/debathena/installer.sh
@@ -155,7 +155,7 @@ ddb="${esc}[1;31;47;5m" # Plus blinking
 
 mirrorsite="mirrors.mit.edu"
 installertype="production"
-distro="precise"
+distro="trusty"
 partitioning="auto"
 arch="i386"
 # That is a space and a tab


### PR DESCRIPTION
Default to trusty for the PXE install
